### PR TITLE
エディタが共有されて大変なことになるのを修正 [closes #25]

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,5 +1,20 @@
 # Be sure to restart your server when you modify this file. Action Cable runs in a loop that does not support auto reloading.
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      self.current_user = find_verified_user
+    end
+
+    protected
+
+    def find_verified_user
+      if current_user = User.find_by(id: cookies.signed[:user_id])
+        current_user
+      else
+        reject_unauthorized_connection
+      end
+    end
   end
 end

--- a/app/channels/post_channel.rb
+++ b/app/channels/post_channel.rb
@@ -1,7 +1,8 @@
 # Be sure to restart your server when you modify this file. Action Cable runs in a loop that does not support auto reloading.
 class PostChannel < ApplicationCable::Channel
   def subscribed
-    stream_from "post_channel_#{current_user.id}" if current_user
+    @post_channel_id = SecureRandom.hex
+    stream_from "post_channel_#{@post_channel_id}"
   end
 
   def unsubscribed
@@ -9,6 +10,7 @@ class PostChannel < ApplicationCable::Channel
   end
 
   def preview(data)
-    PostPreviewJob.perform_later(user: current_user, source: data['source'])
+    PostPreviewJob.perform_later(channel_id: @post_channel_id,
+                                 source: data['source'])
   end
 end

--- a/app/channels/post_channel.rb
+++ b/app/channels/post_channel.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file. Action Cable runs in a loop that does not support auto reloading.
 class PostChannel < ApplicationCable::Channel
   def subscribed
-    stream_from 'post_channel'
+    stream_from "post_channel_#{current_user.id}" if current_user
   end
 
   def unsubscribed
@@ -9,6 +9,6 @@ class PostChannel < ApplicationCable::Channel
   end
 
   def preview(data)
-    PostPreviewJob.perform_later(source: data['source'])
+    PostPreviewJob.perform_later(user: current_user, source: data['source'])
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,12 +7,14 @@ class SessionsController < ApplicationController
   def create
     auth = request.env['omniauth.auth']
     user = User.find_or_create_from(auth)
-    session[:user_id] = user.id
+    # Use cookies for ActionCable authorization
+    cookies.signed[:user_id] = session[:user_id] = user.id
     redirect_to root_url, notice: "Logged in with #{auth['provider'].titleize}"
   end
 
   def destroy
     reset_session
+    cookies.delete(:user_id)
     redirect_to login_url, notice: 'Logged out'
   end
 

--- a/app/jobs/post_preview_job.rb
+++ b/app/jobs/post_preview_job.rb
@@ -1,8 +1,9 @@
 class PostPreviewJob < ApplicationJob
   queue_as :default
 
-  def perform(source:)
-    ActionCable.server.broadcast 'post_channel', preview_html: render_preview(source)
+  def perform(user:, source:)
+    ActionCable.server.broadcast "post_channel_#{user.id}",
+                                 preview_html: render_preview(source)
   end
 
   private

--- a/app/jobs/post_preview_job.rb
+++ b/app/jobs/post_preview_job.rb
@@ -1,14 +1,18 @@
 class PostPreviewJob < ApplicationJob
   queue_as :default
 
-  def perform(user:, source:)
-    ActionCable.server.broadcast "post_channel_#{user.id}",
+  def perform(channel_id:, source:)
+    ActionCable.server.broadcast "post_channel_#{channel_id}",
                                  preview_html: render_preview(source)
   end
 
   private
 
   def render_preview(source)
-    ApplicationController.renderer.render partial: 'posts/preview', locals: { title: source['title'], body: source['body'] }
+    ApplicationController.renderer.render partial: 'posts/preview',
+                                          locals: {
+                                            title: source['title'],
+                                            body: source['body']
+                                          }
   end
 end


### PR DESCRIPTION
- ActionCable の README にしたがって `identified_by` で ActionCable の認証を追加 (ログイン時に署名付き cookies に保存)
- channel にランダム文字列を付加することでチャンネルが共有されることを回避

connects to #25 