### PR TITLE
コードブロックのフォントを変更

### DIFF
--- a/app/assets/stylesheets/_highlight.scss
+++ b/app/assets/stylesheets/_highlight.scss
@@ -1,9 +1,11 @@
 .highlight {
-  border: 1px solid #ddd;
-  font-size: 0.9rem;
-  line-height: 1.5;
-  margin: 2rem auto;
-  padding: 0.9rem;
+  border: 1px solid $border-gray;
+  margin: 1.8rem 0;
+  padding: .9rem;
+
+  code {
+    font-family: Inconsolata, Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  }
 
   // GitHub style syntax highlighter for rouge
   .hll { background-color: #f8f8f8; border: 1px solid #ccc; padding: 6px 10px; border-radius: 3px; }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 @import url(https://fonts.googleapis.com/css?family=Lato);
-@import 'font-awesome';
+@import url(https://fonts.googleapis.com/css?family=Inconsolata);
 
+@import 'font-awesome';
 @import 'materialize';
 
 @import 'variables';


### PR DESCRIPTION
コードのフォントが等幅じゃなくてちょっと見にくかったので等幅フォントに変えました。
それにあわせてちょっと全体の見栄えもいじってます。