### PR TITLE
session ページのレイアウトにも viewport を追加した

### DIFF
--- a/app/views/layouts/sessions.html.slim
+++ b/app/views/layouts/sessions.html.slim
@@ -6,6 +6,7 @@ html
     = csrf_meta_tags
     = action_cable_meta_tag
     = stylesheet_link_tag 'sessions', media: 'all'
+    meta name="viewport" content="width=device-width, initial-scale=1.0"
   body
     .login
       .container


### PR DESCRIPTION
## やったこと

#42 でレイアウトファイルを分けた際に、#39 で入れた viewport を入れていなかったので追加しました（確認しそびれてました 😓 スミマセン）。

## 入れた後の画面

![viewport](https://cloud.githubusercontent.com/assets/1979779/15997291/46218e56-316d-11e6-8d1f-60ce09ea591a.png)
