### PR TITLE
Post の編集/作成のテストを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development, :test do
   gem 'launchy'
   gem 'minitest-rails-capybara', github: 'blowmage/minitest-rails-capybara'
   gem 'minitest-stub_any_instance'
+  gem 'poltergeist'
   gem 'pry-byebug'
   gem 'tapp', git: 'https://github.com/5t111111/tapp.git', branch: 'add-decoration-feature'
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    cliver (0.3.2)
     coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
@@ -160,6 +161,11 @@ GEM
     omniauth-slack (2.3.0)
       omniauth-oauth2 (~> 1.3.1)
     pg (0.18.4)
+    poltergeist (1.9.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -294,6 +300,7 @@ DEPENDENCIES
   minitest-stub_any_instance
   omniauth-slack
   pg
+  poltergeist
   pry-byebug
   puma
   rails (>= 5.0.0.beta3, < 5.1)

--- a/app/assets/javascripts/channels/post.coffee
+++ b/app/assets/javascripts/channels/post.coffee
@@ -1,10 +1,13 @@
 App.post = App.cable.subscriptions.create "PostChannel",
   connected: ->
     # Called when the subscription is ready for use on the server
-    @perform 'preview', source: {
-      title: document.getElementById('post_title').value,
-      body: document.getElementById('post_body').value
-    }
+
+    # TODO: It's better to create this channel only on editor page
+    if document.getElementById('post_title') != null
+      @perform 'preview', source: {
+        title: document.getElementById('post_title').value,
+        body: document.getElementById('post_body').value
+      }
 
   disconnected: ->
     # Called when the subscription has been terminated by the server

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  pre:
+    - sudo curl --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Disable request forgery protection
+  config.action_cable.disable_request_forgery_protection = true
 end

--- a/test/features/authentication_test.rb
+++ b/test/features/authentication_test.rb
@@ -2,13 +2,7 @@ require 'test_helper'
 
 feature 'Authentication' do
   scenario 'Can access posts page when logging in' do
-    stub_slack_login_with 'alice'
-
-    visit login_path
-
-    VCR.use_cassette 'slack/users_info' do
-      click_link 'Login with Slack'
-    end
+    stub_authentication_with 'alice'
 
     visit posts_path
 

--- a/test/features/authentication_test.rb
+++ b/test/features/authentication_test.rb
@@ -7,7 +7,7 @@ feature 'Authentication' do
     visit posts_path
 
     within '.card-title', match: :first do
-      page.must_have_content posts(:alice_in_wonderland).title
+      expect(page).must_have_content posts(:alice_in_wonderland).title
     end
   end
 
@@ -15,11 +15,11 @@ feature 'Authentication' do
     visit posts_path
 
     within '.flash-message__alert' do
-      page.must_have_content 'Please login'
+      expect(page).must_have_content 'Please login'
     end
 
     within '.login__login-link' do
-      page.must_have_content 'Login with Slack'
+      expect(page).must_have_content 'Login with Slack'
     end
   end
 end

--- a/test/features/login_with_slack_test.rb
+++ b/test/features/login_with_slack_test.rb
@@ -5,7 +5,7 @@ feature 'Login with slack' do
     visit login_path
 
     within '.login__login-link' do
-      page.must_have_content 'Login with Slack'
+      expect(page).must_have_content 'Login with Slack'
     end
   end
 
@@ -19,11 +19,11 @@ feature 'Login with slack' do
     end
 
     within '.flash-message__notice' do
-      page.must_have_content 'Logged in with Slack'
+      expect(page).must_have_content 'Logged in with Slack'
     end
 
     within '.navigation__list' do
-      page.must_have_content 'Logout'
+      expect(page).must_have_content 'Logout'
     end
   end
 
@@ -40,7 +40,7 @@ feature 'Login with slack' do
     end
 
     within '.flash-message__alert' do
-      page.must_have_content 'Only team member can login'
+      expect(page).must_have_content 'Only team member can login'
     end
   end
 end

--- a/test/features/markdown_preview_test.rb
+++ b/test/features/markdown_preview_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+feature 'MarkdownPreview' do
+  scenario 'User enters title', js: true do
+    stub_authentication_with 'alice'
+
+    visit new_post_path
+
+    title = 'Through the Looking-Glass, and What Alice Found There'
+
+    fill_in 'post_title', with: title
+
+    within '#post-preview' do
+      page.must_have_content title
+    end
+  end
+
+  scenario 'User enters body', js: true do
+    stub_authentication_with 'alice'
+
+    visit new_post_path
+
+    body = 'One thing was certain, that the white kitten had nothing.'
+
+    fill_in 'post_body', with: body
+
+    within '#post-preview' do
+      page.must_have_content body
+    end
+  end
+
+  scenario 'User enters both title and body', js: true do
+    stub_authentication_with 'alice'
+
+    visit new_post_path
+
+    title = 'Through the Looking-Glass, and What Alice Found There'
+    body = 'One thing was certain, that the white kitten had nothing.'
+
+    fill_in 'post_title', with: title
+    fill_in 'post_body', with: body
+
+    within '#post-preview' do
+      page.must_have_content title
+      page.must_have_content body
+    end
+  end
+end

--- a/test/features/markdown_preview_test.rb
+++ b/test/features/markdown_preview_test.rb
@@ -11,7 +11,7 @@ feature 'MarkdownPreview' do
     fill_in 'post_title', with: title
 
     within '#post-preview' do
-      page.must_have_content title
+      expect(page).must_have_content title
     end
   end
 
@@ -25,7 +25,7 @@ feature 'MarkdownPreview' do
     fill_in 'post_body', with: body
 
     within '#post-preview' do
-      page.must_have_content body
+      expect(page).must_have_content body
     end
   end
 
@@ -41,8 +41,8 @@ feature 'MarkdownPreview' do
     fill_in 'post_body', with: body
 
     within '#post-preview' do
-      page.must_have_content title
-      page.must_have_content body
+      expect(page).must_have_content title
+      expect(page).must_have_content body
     end
   end
 end

--- a/test/features/post_creation_test.rb
+++ b/test/features/post_creation_test.rb
@@ -15,20 +15,20 @@ feature 'PostCreation' do
     click_button 'Save'
 
     within '.flash-message__notice' do
-      page.must_have_content 'Post was successfully created.'
+      expect(page).must_have_content 'Post was successfully created.'
     end
 
     within '.post__title' do
-      page.must_have_content title
+      expect(page).must_have_content title
     end
 
     within '.post__body' do
-      page.must_have_content body
+      expect(page).must_have_content body
     end
 
     post = Post.last
-    post.user.must_equal User.find_by!(nickname: 'alice')
-    post.title.must_equal title
-    post.body.must_equal body
+    expect(post.user).must_equal User.find_by!(nickname: 'alice')
+    expect(post.title).must_equal title
+    expect(post.body).must_equal body
   end
 end

--- a/test/features/post_creation_test.rb
+++ b/test/features/post_creation_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+feature 'PostCreation' do
+  scenario 'User create post', js: true do
+    stub_authentication_with 'alice'
+
+    visit new_post_path
+
+    title = 'Through the Looking-Glass, and What Alice Found There'
+    body = 'One thing was certain, that the white kitten had nothing.'
+
+    fill_in 'post_title', with: title
+    fill_in 'post_body', with: body
+
+    click_button 'Save'
+
+    within '.flash-message__notice' do
+      page.must_have_content 'Post was successfully created.'
+    end
+
+    within '.post__title' do
+      page.must_have_content title
+    end
+
+    within '.post__body' do
+      page.must_have_content body
+    end
+
+    post = Post.last
+    post.user.must_equal User.find_by!(nickname: 'alice')
+    post.title.must_equal title
+    post.body.must_equal body
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,4 +32,18 @@ class ActiveSupport::TestCase
       }
     )
   end
+
+  # Stub whole authentication includes:
+  # - Slack OAuth login
+  # - Visiting login page
+  # - Team checking
+  def stub_authentication_with(nickname)
+    stub_slack_login_with(nickname)
+
+    visit login_path
+
+    VCR.use_cassette 'slack/users_info' do
+      click_link 'Login with Slack'
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,10 +3,15 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'minitest/rails/capybara'
 require 'webmock/minitest'
+require 'capybara/poltergeist'
+
+Capybara.javascript_driver = :poltergeist
+Capybara.server = :puma
 
 VCR.configure do |config|
   config.cassette_library_dir = 'test/cassettes'
   config.hook_into :webmock
+  config.ignore_localhost = true
 end
 
 class ActiveSupport::TestCase


### PR DESCRIPTION
Post の編集/作成のテストを追加しました。

- JS のテスト用に Poltergeist を追加
- ActionCable をテストできるように設定を追加
- Post のプレビュー機能のテストを追加
- Post の新規作成のテストを追加
- PhantomJS 2.1.1 を使うために `circle.yml` を追加 (See https://github.com/reactjs/react-rails/issues/10)
- など
