### PR TITLE
投稿日時が投稿画面に出るようにした Closes #26

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -79,9 +79,8 @@
   }
 }
 
-.post__author {
+.author {
   border-top: 1px solid $border-gray;
-  margin: 1.5rem;
-  padding: 1rem;
+  padding: 1.5rem 0;
   text-align: right;
 }

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -89,6 +89,6 @@
   font-size: .9rem
 }
 
-.author__created_at {
+.author__created-at {
   font-size: .8rem
 }

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -84,3 +84,11 @@
   padding: 1.5rem 0;
   text-align: right;
 }
+
+.author__nickname {
+  font-size: .9rem
+}
+
+.author__created_at {
+  font-size: .8rem
+}

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -8,11 +8,11 @@
       .author
         .row
           .col.s3.offset-s9
-            .post-author__nickname style='font-size: .9rem;'
+            .author__nickname
               | Created by
               span.blue-text
                 |  #{@post.created_by.nickname}
-            .post-author__date.grey-text.text-darken-1 style='font-size: 0.8rem;'
+            .author__created_at.grey-text.text-darken-1
               = @post.created_at
 .row
   .col.s12

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -5,9 +5,15 @@
         = @post.title
       .post__body
         == sanitize(auto_link(markdown_to_html(emojify(@post.body))))
-      .post__author
-        | posted by
-        = " #{@post.created_by.nickname}"
+      .author
+        .row
+          .col.s3.offset-s9
+            .post-author__nickname style='font-size: .9rem;'
+              | Created by
+              span.blue-text
+                |  #{@post.created_by.nickname}
+            .post-author__date.grey-text.text-darken-1 style='font-size: 0.8rem;'
+              = @post.created_at
 .row
   .col.s12
     = link_to edit_post_path(@post), class: 'waves-effect waves-light btn' do

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -12,7 +12,7 @@
               | Created by
               span.blue-text
                 |  #{@post.created_by.nickname}
-            .author__created_at.grey-text.text-darken-1
+            .author__created-at.grey-text.text-darken-1
               = @post.created_at
 .row
   .col.s12

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,5 +11,6 @@ module Kawaiichan
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
- Post の詳細画面に投稿日時が表示されるようにした
- Timezone を Tokyo にした

<img width="837" alt="2016-06-15 0 31 27" src="https://cloud.githubusercontent.com/assets/333180/16048852/892d1b42-3290-11e6-9c3b-3b7617c539f8.png">

投稿一覧画面にも出そうとしましたが、そもそも一覧画面はあまり深く考えずに作ったので拡張しにくいので、一覧のレイアウト自体の見直しも含めて考えたい気持ちです (#47) 。

あとリンクになっていないのにリンクっぽい色になっていて気持ち悪いですが、見た目の華やかさが欲しかったのでこうしてしまいました。

connects to #26