### PR TITLE
Post からみた User の関連名を変えた

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,5 @@
 class Post < ApplicationRecord
-  belongs_to :user
+  belongs_to :created_by, class_name: 'User'
 
   validates :title, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   include Authenticator
 
-  has_many :posts
+  has_many :posts, foreign_key: 'created_by_id'
 
   class << self
     def find_or_create_from(auth)

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -7,7 +7,7 @@
         == sanitize(markdown_to_html(emojify(@post.body)))
       .post__author
         | posted by
-        = " #{@post.user.nickname}"
+        = " #{@post.created_by.nickname}"
 .row
   .col.s12
     = link_to edit_post_path(@post), class: 'waves-effect waves-light btn' do

--- a/db/migrate/20160623025313_rename_column_user_id_to_created_by_id_in_posts.rb
+++ b/db/migrate/20160623025313_rename_column_user_id_to_created_by_id_in_posts.rb
@@ -1,0 +1,5 @@
+class RenameColumnUserIdToCreatedByIdInPosts < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :posts, :user_id, :created_by_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160516050348) do
+ActiveRecord::Schema.define(version: 20160623025313) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,10 +19,10 @@ ActiveRecord::Schema.define(version: 20160516050348) do
   create_table "posts", force: :cascade do |t|
     t.string   "title"
     t.text     "body"
-    t.integer  "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_posts_on_user_id", using: :btree
+    t.integer  "created_by_id"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.index ["created_by_id"], name: "index_posts_on_created_by_id", using: :btree
   end
 
   create_table "users", force: :cascade do |t|
@@ -33,5 +33,5 @@ ActiveRecord::Schema.define(version: 20160516050348) do
     t.string   "uid"
   end
 
-  add_foreign_key "posts", "users"
+  add_foreign_key "posts", "users", column: "created_by_id"
 end

--- a/test/features/post_creation_test.rb
+++ b/test/features/post_creation_test.rb
@@ -27,7 +27,7 @@ feature 'PostCreation' do
     end
 
     post = Post.last
-    expect(post.user).must_equal User.find_by!(nickname: 'alice')
+    expect(post.created_by).must_equal User.find_by!(nickname: 'alice')
     expect(post.title).must_equal title
     expect(post.body).must_equal body
   end

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -14,7 +14,7 @@ alice_in_wonderland:
 
     - so she was considering
     - in her own mind
-  user: alice
+  created_by: alice
   updated_at: <%= Time.zone.parse('2016-05-01 12:34:56') %>
 
 fenced_code_block:
@@ -25,5 +25,5 @@ fenced_code_block:
       puts 'foo'
     end
     ```
-  user: alice
+  created_by: alice
   updated_at: <%= Time.zone.parse('2016-04-01 12:34:56') %>


### PR DESCRIPTION
## やったこと

Post モデルのオブジェクトからアクセスするときに、User はすなわち「その post の __投稿者__」なので、`post.posted_by` で User モデルのオブジェクトが取れるように変更しました。そのほうが読みやすいなと思ったので🐵 