### PR TITLE
Slack 通知を無効にできるようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :development, :test do
   gem 'minitest-stub_any_instance'
   gem 'poltergeist'
   gem 'pry-byebug'
+  gem 'pry-rails'
   gem 'tapp', git: 'https://github.com/5t111111/tapp.git', branch: 'add-decoration-feature'
   gem 'vcr'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,8 @@ GEM
     pry-byebug (3.4.0)
       byebug (~> 9.0)
       pry (~> 0.10)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
     puma (3.6.0)
     rack (2.0.1)
     rack-test (0.6.3)
@@ -307,6 +309,7 @@ DEPENDENCIES
   pg
   poltergeist
   pry-byebug
+  pry-rails
   puma
   rails (~> 5.0.0)
   rails_12factor

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,8 +7,14 @@ class Post < ApplicationRecord
 
   concerning :Notifiable do
     included do
-      after_create_commit :notify_to_create
-      after_update_commit :notify_to_update
+      after_create_commit :notify_to_create if slack_notification_enabled?
+      after_update_commit :notify_to_update if slack_notification_enabled?
+    end
+
+    class_methods do
+      def slack_notification_enabled?
+        Rails.configuration.slack_notification_enabled
+      end
     end
 
     private

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,4 +57,7 @@ Rails.application.configure do
 
   # Kawaiichan's root url
   config.kawaiichan_url = 'http://localhost:3000'
+
+  # Enable/disable Slack notification
+  config.slack_notification_enabled = false
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,4 +89,7 @@ Rails.application.configure do
 
   # Kawaiichan's root url
   config.kawaiichan_url = ENV['KAWAIICHAN_URL']
+
+  # Enable/disable Slack notification
+  config.slack_notification_enabled = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,7 @@ Rails.application.configure do
 
   # Kawaiichan's root url
   config.kawaiichan_url = 'http://localhost:3000'
+
+  # Enable/disable Slack notification
+  config.slack_notification_enabled = true
 end


### PR DESCRIPTION
<!--
↑ Pull Request のタイトルに [closes #nnn] という文言を追加すると、この PR がマージされたときにその番号の issue を同時に close してくれます
-->

## やったこと

必ず Slack 通知が送信される仕様だと開発するときにちょっとやりづらい感があったので無効にできる config を追加しました。

- `config.slack_notification_enabled` で制御する
- `development` のみ `false` で production/test は `true`
- デフォルトは「通知あり」にして無効にしたいときだけ設定するようにしようかとも思ったけど、まあわかりやすいかと思っていずれの場合も設定必須にした
- ついでに  `pry-rails` インストールしてしまいました

## 対応する issue

<!--
connects to #nnn みたいに書くと、Waffle.io でその issue と PR をくっつけて表示してくれます
-->

nothing