### PR TITLE
たまにテストが落ちる問題を修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,9 @@ gem 'truncate_html'
 gem 'uglifier'
 
 group :development, :test do
+  gem 'database_cleaner'
   gem 'launchy'
+  gem 'minitest-around'
   gem 'minitest-rails-capybara'
   gem 'minitest-stub_any_instance'
   gem 'poltergeist'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
     connection_pool (2.2.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     dotenv (2.1.1)
     dotenv-rails (2.1.1)
@@ -125,6 +126,8 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
+    minitest-around (0.4.0)
+      minitest (~> 5.0)
     minitest-capybara (0.8.2)
       capybara (~> 2.2)
       minitest (~> 5.0)
@@ -293,6 +296,7 @@ PLATFORMS
 
 DEPENDENCIES
   coffee-rails
+  database_cleaner
   dotenv-rails
   font-awesome-rails
   gemoji
@@ -302,6 +306,7 @@ DEPENDENCIES
   launchy
   listen
   materialize-sass
+  minitest-around
   minitest-rails-capybara
   minitest-stub_any_instance
   omniauth-slack

--- a/test/features/markdown_preview_test.rb
+++ b/test/features/markdown_preview_test.rb
@@ -5,6 +5,7 @@ feature 'MarkdownPreview' do
     stub_authentication_with 'alice'
 
     visit new_post_path
+    wait_action_cable_subscription
 
     title = 'Through the Looking-Glass, and What Alice Found There'
 
@@ -19,6 +20,7 @@ feature 'MarkdownPreview' do
     stub_authentication_with 'alice'
 
     visit new_post_path
+    wait_action_cable_subscription
 
     body = 'One thing was certain, that the white kitten had nothing.'
 
@@ -33,6 +35,7 @@ feature 'MarkdownPreview' do
     stub_authentication_with 'alice'
 
     visit new_post_path
+    wait_action_cable_subscription
 
     title = 'Through the Looking-Glass, and What Alice Found There'
     body = 'One thing was certain, that the white kitten had nothing.'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,5 +62,8 @@ class Capybara::Rails::TestCase
     end
   end
 
+  # Wait a sec because tests will fail if a channel is not subscribed yet
+  def wait_action_cable_subscription
+    sleep 1
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,8 @@ require 'rails/test_help'
 require 'minitest/rails/capybara'
 require 'webmock/minitest'
 require 'capybara/poltergeist'
+require 'minitest/around'
+require 'database_cleaner'
 
 Capybara.javascript_driver = :poltergeist
 Capybara.server = :puma
@@ -13,6 +15,8 @@ VCR.configure do |config|
   config.hook_into :webmock
   config.ignore_localhost = true
 end
+
+DatabaseCleaner.strategy = :truncation
 
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
@@ -45,5 +49,18 @@ class ActiveSupport::TestCase
     VCR.use_cassette 'slack/users_info' do
       click_link 'Login with Slack'
     end
+  end
+end
+
+class Capybara::Rails::TestCase
+  around do |test|
+    if metadata[:js]
+      page.driver.clear_memory_cache
+      DatabaseCleaner.cleaning(&test)
+    else
+      test.call
+    end
+  end
+
   end
 end


### PR DESCRIPTION
<!--
↑ Pull Request のタイトルに [closes #nnn] という文言を追加すると、この PR がマージされたときにその番号の issue を同時に close してくれます
-->

## やったこと

たまにテストが落ちる原因は、JS driver を利用するテストで以下の複数の要因が組み合わさっていたようです。

1. データベースの状態がリセットされない
2. PhantomJS のブラウザキャッシュが残っている
3. ActionCable が subscribe される前にテストデータがインプットされる

1 は database cleaner の導入で対応しました。

2 は `page.driver.clear_memory_cache` で対応しました。

3 は… subscribe したことをチェックできれば良いと思ったのですが、マルチセッションもあるので特定の PostChannel の subscribe 状態をチェックする方法がわからず、仕方なく `sleep 1` を挟むことで対応しています。

テストを100回実行して問題なさそうなので、おそらくこれでほぼ改善したかと思います。たぶん。

## 対応する issue

<!--
connects to #nnn みたいに書くと、Waffle.io でその issue と PR をくっつけて表示してくれます
-->

なし