### PR TITLE
文字列リテラルにダブルクオートを使うよう .rubocop.yml を修正

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,3 +37,6 @@ Style/Lambda:
 
 Style/IfInsideElse:
   Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes


### PR DESCRIPTION
<!--
↑ Pull Request のタイトルに [closes #nnn] という文言を追加すると、この PR がマージされたときにその番号の issue を同時に close してくれます
-->

## やったこと

ダブルクオートにしました。


## 対応する issue

<!--
connects to #nnn みたいに書くと、Waffle.io でその issue と PR をくっつけて表示してくれます
-->

なし

