### PR TITLE
CSS を BEM の規約に合わせるために scss-lint の設定を変えた

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -94,7 +94,7 @@ linters:
     severity: warning
   SelectorFormat:
     enabled: true
-    convention: hyphenated_lowercase
+    convention: hyphenated_BEM
   Shorthand:
     enabled: true
     severity: warning


### PR DESCRIPTION
## やったこと

CSS の規約を BEM に（BEM っぽく）していきたいので、 scss-lint の設定を変更しました。

scss-lint では `strict_BEM` と `hyphenated_BEM` という設定をサポートしていますが、わたしたちが使っているのは `hyphenated_BEM` にあたるため、それに変えています。

- https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#selectorformat
- https://github.com/brigade/scss-lint/blob/e6d20f537d021445da9583cbe1ec29bcded5ec32/spec/scss_lint/linter/selector_format_spec.rb#L584-L588

🐶 #64 で `__` を CSS クラス名に使っているところで怒られたのでこの PR を出しました。

## 対応する issue

なし