### PR TITLE
CSS 内の小数の値はさいしょの 0 を書かない

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,144 +1,192 @@
 scss_files: "**/*.scss"
+
 linters:
   BangFormat:
     enabled: true
     space_before_bang: true
     space_after_bang: false
+
   BorderZero:
     enabled: false
     convention: zero
+
   ColorKeyword:
     enabled: true
     severity: warning
+
   ColorVariable:
     enabled: true
+
   Comment:
     enabled: true
+
   DebugStatement:
     enabled: true
+
   DeclarationOrder:
     enabled: true
+
   DuplicateProperty:
     enabled: true
+
   ElsePlacement:
     enabled: true
     style: same_line
+
   EmptyLineBetweenBlocks:
     enabled: true
     ignore_single_line_blocks: true
+
   EmptyRule:
     enabled: true
+
   FinalNewline:
     enabled: true
     present: true
+
   HexLength:
     enabled: false
     style: short
+
   HexNotation:
     enabled: true
     style: lowercase
+
   HexValidation:
     enabled: true
+
   IdSelector:
     enabled: true
+
   ImportantRule:
     enabled: true
+
   ImportPath:
     enabled: true
     leading_underscore: false
     filename_extension: false
+
   Indentation:
     enabled: true
     allow_non_nested_indentation: false
     character: space
     width: 2
+
   MergeableSelector:
     enabled: true
     force_nesting: true
+
   NameFormat:
     enabled: true
     allow_leading_underscore: true
     convention: hyphenated_lowercase
+
   NestingDepth:
     enabled: true
     max_depth: 4
     severity: warning
+
   PlaceholderInExtend:
     enabled: false
+
   PropertyCount:
     enabled: true
     include_nested: false
     max_properties: 10
 # NOTE 冗長な書き方になってしまうこともあるので false にしたけど、
 #      CSS 詳しくないので実際はあったほうがいいのかも。。
+
   PropertySortOrder:
     enabled: false
     ignore_unspecified: false
     severity: warning
     separate_groups: false
+
   PropertySpelling:
     enabled: true
     extra_properties: []
+
   QualifyingElement:
     enabled: true
     allow_element_with_attribute: false
     allow_element_with_class: false
     allow_element_with_id: false
     severity: warning
+
   SelectorDepth:
     enabled: true
     max_depth: 2
     severity: warning
+
   SelectorFormat:
     enabled: true
     convention: hyphenated_BEM
+
   Shorthand:
     enabled: true
     severity: warning
+
   SingleLinePerProperty:
     enabled: true
     allow_single_line_rule_sets: true
+
   SingleLinePerSelector:
     enabled: true
+
   SpaceAfterComma:
     enabled: true
+
   SpaceAfterPropertyColon:
     enabled: true
     style: one_space
+
   SpaceAfterPropertyName:
     enabled: true
+
   SpaceBeforeBrace:
     enabled: true
     style: space
     allow_single_line_padding: false
+
   SpaceBetweenParens:
     enabled: true
     spaces: 0
+
   StringQuotes:
     enabled: true
     style: double_quotes
+
   TrailingSemicolon:
     enabled: true
+
   TrailingZero:
     enabled: false
+
   UnnecessaryMantissa:
     enabled: true
+
   UnnecessaryParentReference:
     enabled: true
+
   UrlFormat:
     enabled: true
+
   UrlQuotes:
     enabled: true
+
   VariableForProperty:
     enabled: false
     properties: []
+
   VendorPrefixes:
     enabled: true
     identifier_list: bourbon
     include: []
     exclude: []
+
   ZeroUnit:
     enabled: true
     severity: warning
+
   Compass::PropertyWithMixin:
     enabled: false

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -52,9 +52,6 @@ linters:
     allow_non_nested_indentation: false
     character: space
     width: 2
-  LeadingZero:
-    enabled: true
-    style: include_zero
   MergeableSelector:
     enabled: true
     force_nesting: true


### PR DESCRIPTION
## やったこと

https://github.com/yochiyochirb/kawaiichan/pull/64#discussion_r77309151

のような指摘に対応するために `LeadingZero` の設定を変更しました。

https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md#leadingzero

元々この repo で使っている `.scss-lint.yml` の中身は [kajaeru](https://github.com/yochiyochirb/kajaeru/) からもってきたものですが、当時この `LeadingZero` をなんで敢えて `include_zero` にしたのかよくわからなかったので、デフォルト設定値に戻したかたちになります 🙇 

https://github.com/yochiyochirb/kajaeru/pull/91/files#diff-17d88a0ede66749ec03514e034de8f73R57

## 対応する issue

なし