### PR TITLE
Remove unnecessary self reference

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -31,7 +31,7 @@ class Post < ApplicationRecord
       {
         channel: ENV["SLACK_POST_CHANNEL"],
         text: "#{created_by.nickname} #{action}d *#{title}*.",
-        attachments: attachment(self),
+        attachments: attachment,
         as_user: false,
         username: "kawaiichan",
         icon_emoji: ":new_moon_with_face:"
@@ -42,13 +42,13 @@ class Post < ApplicationRecord
       @client ||= Slack::Web::Client.new
     end
 
-    def attachment(post)
+    def attachment
       JSON.generate(
         [
           {
-            title: post.title,
-            title_link: "#{Rails.configuration.kawaiichan_url}/posts/#{post.id}",
-            text: post.body,
+            title: title,
+            title_link: "#{Rails.configuration.kawaiichan_url}/posts/#{id}",
+            text: body,
             mrkdwn_in: ["text"]
           }
         ]


### PR DESCRIPTION
<!--
↑ Pull Request のタイトルに [closes #nnn] という文言を追加すると、この PR がマージされたときにその番号の issue を同時に close してくれます
-->
## やったこと

`Notifiable#attachment` はインスタンスメソッドとして `include` されるのに `self` を引数で渡して自己参照するのが不自然に感じたので修正しました。
## 対応する issue

<!--
connects to #nnn みたいに書くと、Waffle.io でその issue と PR をくっつけて表示してくれます
-->

なし
