### PR TITLE
table 関連のタグが sanitize で削除されることに対応

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -12,5 +12,14 @@ module Kawaiichan
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
     config.time_zone = "Tokyo"
+
+    # SanitizeHelper configuration
+    config.action_view.sanitized_allowed_tags = %w(strong em b i p code pre tt samp kbd var sub
+                                                   sup dfn cite big small address hr br div span
+                                                   h1 h2 h3 h4 h5 h6 ul ol li dl dt dd abbr
+                                                   acronym a img blockquote del ins) + \
+                                                %w(table thead tbody tr th td tbody tfoot) # added to the default
+    config.action_view.sanitized_allowed_attributes = %w(href src width height alt cite datetime
+                                                         title class name xml:lang abbr)
   end
 end


### PR DESCRIPTION
<!--
↑ Pull Request のタイトルに [closes #nnn] という文言を追加すると、この PR がマージされたときにその番号の issue を同時に close してくれます
-->

## やったこと

サニタイズの設定を `config/application.rb` に明示的に「デフォルト設定」+「テーブル関連のタグ」で指定するようにして table 関連のタグが消されないようにしました。

今後も同様になぜかタグが消されちゃった場合はこの辺をいじってください。


## 対応する issue

<!--
connects to #nnn みたいに書くと、Waffle.io でその issue と PR をくっつけて表示してくれます
-->

なし

